### PR TITLE
chore: Update gitignore for coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ go.work
 
 # .env file
 /.env
+
+# Coverage reports
+/covprofile
+/coverage.html
+


### PR DESCRIPTION
## Context
Updates the root `.gitignore` to ignore autogenerated coverage report files (generated with `make coverage`)
