### PR TITLE
fix: Semester wise course getter

### DIFF
--- a/amizone/amizone.go
+++ b/amizone/amizone.go
@@ -22,7 +22,7 @@ const (
 	scheduleEndpointTemplate = "/Calendar/home/GetDiaryEvents?start=%s&end=%s"
 	examScheduleEndpoint     = "/Examination/ExamSchedule"
 	currentCoursesEndpoint   = "/Academics/MyCourses"
-	coursesEndpoint          = "/CourseListSemWise"
+	coursesEndpoint          = currentCoursesEndpoint + "/CourseListSemWise"
 
 	scheduleEndpointTimeFormat = "2006-01-02"
 

--- a/amizone/amizone_test.go
+++ b/amizone/amizone_test.go
@@ -280,6 +280,20 @@ func TestClient_GetCurrentCourses(t *testing.T) {
 			},
 		},
 		{
+			name:   "amizone client is logged is and returns the (mock) sem-wise courses page",
+			client: loggedInClient,
+			setup: func(g *WithT) {
+				err := mock.GockRegisterSemWiseCoursesPage()
+				g.Expect(err).ToNot(HaveOccurred())
+			},
+			coursesMatcher: func(g *WithT, courses amizone.Courses) {
+				g.Expect(courses).To(HaveLen(8))
+			},
+			errMatcher: func(g *WithT, err error) {
+				g.Expect(err).ToNot(HaveOccurred())
+			},
+		},
+		{
 			name:   "amizone client is not logged in and returns the login page",
 			client: nonLoggedInClient,
 			setup: func(g *WithT) {

--- a/amizone/internal/mock/routes.go
+++ b/amizone/internal/mock/routes.go
@@ -104,6 +104,15 @@ func GockRegisterCurrentCoursesPage() error {
 	return nil
 }
 
+func GockRegisterSemWiseCoursesPage() error {
+	mockCourses, err := CoursesPageSemWise.Open()
+	if err != nil {
+		return errors.New("failed to open mock courses page: " + err.Error())
+	}
+	GockRegisterAuthenticatedGet("/Academics/MyCourses", mockCourses)
+	return nil
+}
+
 // GockRegisterAuthenticatedGet registers an authenticated GET request for the relative endpoint passed.
 // The second parameter is used as the response body of the request.
 func GockRegisterAuthenticatedGet(endpoint string, responseBody io.Reader) {

--- a/amizone/internal/mock/testdata.go
+++ b/amizone/internal/mock/testdata.go
@@ -23,5 +23,6 @@ const (
 	HomePageLoggedIn    File = "testdata/home_page_logged_in.html"
 	LoginPage           File = "testdata/login_page.html"
 	CoursesPage         File = "testdata/my_courses.html"
+	CoursesPageSemWise  File = "testdata/courses_semwise.html"
 	IDCardPage          File = "testdata/id_card_page.html"
 )

--- a/amizone/internal/mock/testdata/courses_semwise.html
+++ b/amizone/internal/mock/testdata/courses_semwise.html
@@ -1,0 +1,243 @@
+<div id="no-more-tables">
+  <table class="table table-bordered table-striped table-condensed">
+    <thead class="cf">
+    <tr>
+      <th>Course Code</th>
+      <th>Course Name</th>
+      <th>Type</th>
+      <th>Course Syllabus</th>
+      <th>Session Plan</th>
+      <th>Course Material</th>
+      <th>Attendance</th>
+      <th>Internal Asses.</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td data-title="Course Code">EVS102</td>
+      <td data-title="Course Name">Env Sc</td>
+      <td data-title="Type">Compulsory</td>
+      <td data-title="Course Syllabus"><a target=_blank
+                                          href="https://amizone.net/AdminAmizone/WebForms/Handler.ashx?Type=2&ID=NewSyllabus/42697353-9999-487f-a7d9-b9c3b1fb1d2d.doc"
+                                          id="no-link"><img src="../../Images/ProgramStr.gif"
+                                                            border=0/></a></td>
+      <td data-title="Session Plan">
+        <button onclick="FnShow('900855','0')" class="btn-xs btn btn-primary btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Course Material">
+        <button onclick="FnShowACM('900855')" class="btn-xs btn btn-yellow btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Attendance">
+        <button onclick="FnAttendance('900855')" class="btn-xs btn btn-purple btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">46/48 (95.83)</i>
+        </button>
+      </td>
+      <td data-title="Internal Asses.">35.00[30.00+5.00]/40.00</td>
+    </tr>
+    <tr>
+      <td data-title="Course Code">USC208</td>
+      <td data-title="Course Name">Discrete Mathematical Structures</td>
+      <td data-title="Type">Compulsory</td>
+      <td data-title="Course Syllabus"><a target=_blank
+                                          href="https://amizone.net/AdminAmizone/WebForms/Handler.ashx?Type=2&ID=NewSyllabus/bf75daa2-1a88-4036-9460-757c1d203636.docx"
+                                          id="no-link"><img src="../../Images/ProgramStr.gif"
+                                                            border=0/></a></td>
+      <td data-title="Session Plan">
+        <button onclick="FnShow('900900','0')" class="btn-xs btn btn-primary btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Course Material">
+        <button onclick="FnShowACM('900900')" class="btn-xs btn btn-yellow btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Attendance">
+        <button onclick="FnAttendance('900900')" class="btn-xs btn btn-purple btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">44/48 (91.67)</i>
+        </button>
+      </td>
+      <td data-title="Internal Asses.">30.00[26.00+4.00]/40.00</td>
+    </tr>
+    <tr>
+      <td data-title="Course Code">IT201</td>
+      <td data-title="Course Name">Java Programming</td>
+      <td data-title="Type">Compulsory</td>
+      <td data-title="Course Syllabus"><a target=_blank
+                                          href="https://amizone.net/AdminAmizone/WebForms/Handler.ashx?Type=2&ID=NewSyllabus/11b239c7-41ef-45a1-9a1d-33417b1b97b0.pdf"
+                                          id="no-link"><img src="../../Images/ProgramStr.gif"
+                                                            border=0/></a></td>
+      <td data-title="Session Plan">
+        <button onclick="FnShow('900902','0')" class="btn-xs btn btn-primary btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Course Material">
+        <button onclick="FnShowACM('900902')" class="btn-xs btn btn-yellow btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Attendance">
+        <button onclick="FnAttendance('900902')" class="btn-xs btn btn-purple btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">69/71 (97.18)</i>
+        </button>
+      </td>
+      <td data-title="Internal Asses.">39.25[34.25+5.00]/40.00</td>
+    </tr>
+    <tr>
+      <td data-title="Course Code">MATS201</td>
+      <td data-title="Course Name">Material Science</td>
+      <td data-title="Type">Compulsory</td>
+      <td data-title="Course Syllabus"><a target=_blank
+                                          href="https://amizone.net/AdminAmizone/WebForms/Handler.ashx?Type=2&ID=NewSyllabus/4519d32f-81c9-4c46-9151-6891ec956bf5.doc"
+                                          id="no-link"><img src="../../Images/ProgramStr.gif"
+                                                            border=0/></a></td>
+      <td data-title="Session Plan">
+        <button onclick="FnShow('900888','0')" class="btn-xs btn btn-primary btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Course Material">
+        <button onclick="FnShowACM('900888')" class="btn-xs btn btn-yellow btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Attendance">
+        <button onclick="FnAttendance('900888')" class="btn-xs btn btn-purple btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">30/30 (100.00)</i>
+        </button>
+      </td>
+      <td data-title="Internal Asses.">32.00[27.00+5.00]/40.00</td>
+    </tr>
+    <tr>
+      <td data-title="Course Code">USC202</td>
+      <td data-title="Course Name">Operating System</td>
+      <td data-title="Type">Compulsory</td>
+      <td data-title="Course Syllabus"><a target=_blank
+                                          href="https://amizone.net/AdminAmizone/WebForms/Handler.ashx?Type=2&ID=NewSyllabus/33b23e5f-7abb-4bf4-8317-c9fd9451b2d1.docx"
+                                          id="no-link"><img src="../../Images/ProgramStr.gif"
+                                                            border=0/></a></td>
+      <td data-title="Session Plan">
+        <button onclick="FnShow('900900','0')" class="btn-xs btn btn-primary btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Course Material">
+        <button onclick="FnShowACM('900900')" class="btn-xs btn btn-yellow btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Attendance">
+        <button onclick="FnAttendance('900900')" class="btn-xs btn btn-purple btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">66/66 (100.00)</i>
+        </button>
+      </td>
+      <td data-title="Internal Asses.">37.25[32.25+5.00]/40.00</td>
+    </tr>
+    <tr>
+      <td data-title="Course Code">BS207</td>
+      <td data-title="Course Name">Self-Reliance and Socialization</td>
+      <td data-title="Type">Compulsory</td>
+      <td data-title="Course Syllabus"><a target=_blank
+                                          href="https://amizone.net/AdminAmizone/WebForms/Handler.ashx?Type=2&ID=NewSyllabus/76ec4004-a222-494f-bec3-e6eef2b9cb3a.pdf"
+                                          id="no-link"><img src="../../Images/ProgramStr.gif"
+                                                            border=0/></a></td>
+      <td data-title="Session Plan">
+        <button onclick="FnShow('111365','0')" class="btn-xs btn btn-primary btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Course Material">
+        <button onclick="FnShowACM('111365')" class="btn-xs btn btn-yellow btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Attendance">
+        <button onclick="FnAttendance('111365')" class="btn-xs btn btn-purple btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">36/39 (92.31)</i>
+        </button>
+      </td>
+      <td data-title="Internal Asses.">35.50[31.50+4.00]/50.00</td>
+    </tr>
+    <tr>
+      <td data-title="Course Code">USC204</td>
+      <td data-title="Course Name">UUS</td>
+      <td data-title="Type">Compulsory</td>
+      <td data-title="Course Syllabus"><a target=_blank
+                                          href="https://amizone.net/AdminAmizone/WebForms/Handler.ashx?Type=2&ID=NewSyllabus/o88b1f91-b0b5-44c3-8561-f1f8eaafe755.docx"
+                                          id="no-link"><img src="../../Images/ProgramStr.gif"
+                                                            border=0/></a></td>
+      <td data-title="Session Plan">
+        <button onclick="FnShow('900900','0')" class="btn-xs btn btn-primary btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Course Material">
+        <button onclick="FnShowACM('900900')" class="btn-xs btn btn-yellow btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Attendance">
+        <button onclick="FnAttendance('900900')" class="btn-xs btn btn-purple btn-block"><i
+          class="ace-icon fa fa-eye bigger-110">47/47 (100.00)</i>
+        </button>
+      </td>
+      <td data-title="Internal Asses.">27.00[22.00+5.00]/40.00</td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+<div id="no-more-tables">
+  <table class="table table-bordered table-striped table-condensed">
+    <thead class="cf">
+    <tr>
+      <th colspan="10">Open/Domain/FBL Courses</th>
+    </tr>
+    <tr>
+      <th>Course Code-</th>
+      <th>Course Name-</th>
+      <th>Type-</th>
+      <th>Course Syllabus-</th>
+      <th>Session Plan-</th>
+      <th>Attendance-</th>
+      <th>Internal Asses.-</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td data-title="Course Code">
+        FREN144
+      </td>
+      <td data-title="Course Name">
+        French Through Communicative Approach
+      </td>
+      <td data-title="Type">
+        Open/Domain/FBL
+      </td>
+      <td data-title="Course Syllabus">
+        <a target=_blank
+           href="https://amizone.net/AdminAmizone/WebForms/Handler.ashx?Type=2&ID=NewSyllabus/6dc4c5c4-0a20-458f-bbad-4f2f07803afc.pdf"
+           id="no-link"><img src="../../Images/ProgramStr.gif" border=0/></a>
+      </td>
+      <td data-title="Session Plan">
+        <button onclick="FnShow('1011111','90592')" class="btn-xs btn btn-primary"><i
+          class="ace-icon fa fa-eye bigger-110">View</i></button>
+      </td>
+      <td data-title="Attendance">
+        <button onclick="Fnattendance2('1011111','90592')" class="btn-xs btn btn-purple "><i
+          class="ace-icon fa fa-eye bigger-110">12/15 (80.00)</i></button>
+      </td>
+      <td data-title="Internal Asses.">
+        30.00[29.00+1.00]/40.00
+      </td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+<div class="modal fade" id="kjlsgd" role="dialog">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <h4 class="modal-title">Your Achivements </h4>
+      </div>
+      <div id="modeledit" class="modal-body">
+      </div>
+      <div class="modal-footer">
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+</script>

--- a/amizone/internal/parse/courses_test.go
+++ b/amizone/internal/parse/courses_test.go
@@ -16,8 +16,19 @@ func TestCourses(t *testing.T) {
 		errMatcher     func(g *GomegaWithT, err error)
 	}{
 		{
-			name:     "valid courses page",
+			name:     "current courses page",
 			bodyFile: mock.CoursesPage,
+			coursesMatcher: func(g *GomegaWithT, courses models.Courses) {
+				g.Expect(courses).ToNot(BeNil())
+				g.Expect(len(courses)).To(Equal(8))
+			},
+			errMatcher: func(g *GomegaWithT, err error) {
+				g.Expect(err).ToNot(HaveOccurred())
+			},
+		},
+		{
+			name:     "semester wise courses page",
+			bodyFile: mock.CoursesPageSemWise,
 			coursesMatcher: func(g *GomegaWithT, courses models.Courses) {
 				g.Expect(courses).ToNot(BeNil())
 				g.Expect(len(courses)).To(Equal(8))


### PR DESCRIPTION
## Why
GetCourses() has been broken because it queries an invalid endpoint and the parses it shares with GetCurrentCourses didn't work for the more limited
markup returned by the semester-wise endpoint. This PR fixes these issues and adds test cases to match.
