### PR TITLE
ci: Add fly.io deploy config

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,47 @@
+app = "amizone"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[build]
+  dockerfile = "prod.Dockerfile"
+
+[env]
+  PORT = "8081"
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  internal_port = 8081
+  protocol = "tcp"
+  script_checks = []
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = false
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls"]
+    port = 443
+
+#  [services.ports.tls_options]
+#    alpn = ["h2"]
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"
+
+#  [[services.http_checks]]
+#    interval = "2s"
+#	method = "get"
+#	path = "/"
+#	protocol = "https"

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1.3-labs
+FROM golang:1.18-alpine as go
+WORKDIR /app
+COPY . ./
+RUN <<EOF
+go mod download
+go build -o amizone-api-server cmd/amizone-api-server/server.go
+EOF
+
+FROM alpine:latest as tailscale
+WORKDIR /app
+COPY . ./
+ENV TSFILE=tailscale_1.26.1_amd64.tgz
+RUN wget https://pkgs.tailscale.com/stable/${TSFILE} && tar xzf ${TSFILE} --strip-components=1
+COPY . ./
+
+FROM alpine:latest
+WORKDIR /app
+RUN apk --no-cache add ca-certificates iptables ip6tables
+COPY --from=go /app/amizone-api-server ./
+COPY --from=tailscale /app/tailscale ./
+COPY --from=tailscale /app/tailscaled ./
+RUN mkdir -p /var/run/tailscale /var/cache/tailscale /var/lib/tailscale
+
+COPY <<EOF ./start.sh
+#!/bin/sh
+/app/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock &
+/app/tailscale up --authkey="\${TAILSCALE_AUTHKEY}" --hostname=fly-app
+/app/amizone-api-server
+EOF
+RUN chmod +x start.sh
+
+ENV GRPC_GO_LOG_SEVERITY_LEVEL=info
+ENV GRPC_GO_LOG_VERBOSITY_LEVEL=99
+
+EXPOSE 8081
+
+CMD ["./start.sh"]


### PR DESCRIPTION
## What
Adds the deployment configuration for the prod deployment on fly.io plus the prod dockerfile.
The deployment has been up and reliable for months, should be replicable for others looking to host their own.
