### PR TITLE
ci: Add `integration` build tag to golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 run:
   go: "1.18"
+  build-tags:
+    - "integration"
   skip-dirs-use-default: true
   skip-dirs:
     - "server/gen"


### PR DESCRIPTION
## What

Adds missing `integration` build tag to the golangci-lint config so it
also checks the integration test files.
