### PR TITLE
chore!: move faculty feedback params to POST body

### DIFF
--- a/server/proto/v1/amizone.proto
+++ b/server/proto/v1/amizone.proto
@@ -101,7 +101,10 @@ service AmizoneService {
     option (google.api.http) = {delete: "/api/v1/wifi_mac/{address}"};
   }
   rpc FillFacultyFeedback(FillFacultyFeedbackRequest) returns (FillFacultyFeedbackResponse) {
-    option (google.api.http) = {post: "/api/v1/faculty/feedback/submit"};
+    option (google.api.http) = {
+      post: "/api/v1/faculty/feedback/submit",
+      body: "*"
+    };
   }
 }
 


### PR DESCRIPTION
For the sake of proper HTTP semantics, we do it.
