### PR TITLE
chore: Validate mac registration

### DIFF
--- a/amizone/amizone_test.go
+++ b/amizone/amizone_test.go
@@ -507,6 +507,7 @@ func TestClient_RegisterWifiMac(t *testing.T) {
 	nonLoggedInClient := getNonLoggedInClient(g)
 
 	macNew := macStringtoMac(mock.ValidMacNew, g)
+	mac2 := macStringtoMac(mock.ValidMac2, g)
 
 	infoOneShot, err := mock.WifiPageOneSlot.Open()
 	g.Expect(err).ToNot(HaveOccurred())
@@ -561,7 +562,7 @@ func TestClient_RegisterWifiMac(t *testing.T) {
 		{
 			name:        "client: logged in; mac: valid; free slots: 1, bypass: false",
 			client:      loggedInClient,
-			input:       RegisterMacArgs{A: macNew, O: false},
+			input:       RegisterMacArgs{A: mac2, O: false},
 			dataMatcher: DummyMatcher[Empty],
 			errMatcher:  NoError,
 			setup: func(g *WithT) {
@@ -570,7 +571,7 @@ func TestClient_RegisterWifiMac(t *testing.T) {
 					"__RequestVerificationToken": {verificationToken},
 					"Amizone_Id":                 {mock.ValidUser},
 					"Mac1":                       {mock.ValidMac1},
-					"Mac2":                       {mock.ValidMacNew},
+					"Mac2":                       {mock.ValidMac2},
 					"Name":                       {"DoesntMatter"},
 				}))
 			},

--- a/amizone/models/class_schedule.go
+++ b/amizone/models/class_schedule.go
@@ -3,6 +3,8 @@ package models
 import (
 	"sort"
 	"time"
+
+	"github.com/samber/lo"
 )
 
 type AttendanceState int
@@ -37,14 +39,10 @@ func (s *ClassSchedule) Sort() {
 }
 
 func (s *ClassSchedule) FilterByDate(t time.Time) ClassSchedule {
-	var filtered ClassSchedule
-	for _, class := range *s {
-		// Truncate the time to a day.
-		tDate := t.Truncate(time.Hour * 24)
-
-		if difference := class.StartTime.Sub(tDate).Hours(); difference > 0 && difference < 24 {
-			filtered = append(filtered, class)
-		}
-	}
-	return filtered
+	// Truncate the time to a day.
+	targetDate := t.Truncate(time.Hour * 24)
+	return lo.Filter(*s, func(class ScheduledClass, _ int) bool {
+		timeDelta := class.StartTime.Sub(targetDate).Hours()
+		return timeDelta > 0 && timeDelta < 24
+	})
 }

--- a/amizone/models/wifi_mac_info.go
+++ b/amizone/models/wifi_mac_info.go
@@ -1,6 +1,10 @@
 package models
 
-import "net"
+import (
+	"net"
+
+	"github.com/samber/lo"
+)
 
 type WifiMacInfo struct {
 	RegisteredAddresses []net.HardwareAddr
@@ -26,10 +30,7 @@ func (i *WifiMacInfo) HasFreeSlot() bool {
 }
 
 func (i *WifiMacInfo) IsRegistered(mac net.HardwareAddr) bool {
-	for _, m := range i.RegisteredAddresses {
-		if m.String() == mac.String() {
-			return true
-		}
-	}
-	return false
+	return lo.SomeBy(i.RegisteredAddresses, func(addr net.HardwareAddr) bool {
+		return addr.String() == mac.String()
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.3
 	github.com/joho/godotenv v1.4.0
+	github.com/microcosm-cc/bluemonday v1.0.23
 	github.com/onsi/gomega v1.19.0
+	github.com/samber/lo v1.38.1
 	golang.org/x/net v0.8.0
 	golang.org/x/text v0.8.0
 	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd
@@ -16,7 +18,6 @@ require (
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/h2non/gock.v1 v1.1.2
 	k8s.io/klog/v2 v2.60.1
-	github.com/microcosm-cc/bluemonday v1.0.23
 )
 
 require (
@@ -25,6 +26,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
+	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
+github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
+github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -107,6 +109,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -125,8 +129,6 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 h1:HVyaeDAYux4pnY+D/SiwmLOR36ewZ4iGQIIrtnuCjFA=
-golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -148,16 +150,12 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
 golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
## Summary

Adds validation for WiFi mac registration. Additionally introduces the `lo` library and refactors
some go-style filters with lo's elegant, functional style API.
